### PR TITLE
advance OpenJDK 17

### DIFF
--- a/Ch01/01_03-solution-deploy-a-jenkins-server/jenkins-server-automated-installation.sh
+++ b/Ch01/01_03-solution-deploy-a-jenkins-server/jenkins-server-automated-installation.sh
@@ -22,7 +22,7 @@ apt update
 apt-get -y upgrade
 
 apt-get -y install \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     nginx \
     ca-certificates \
     curl \


### PR DESCRIPTION
Script fails because of java version being too old, jdk 17 fixes that

<!-- This repository *does not* accept pull requests (PRs). All pull requests will be closed. See CONTRIBUTING.md for further details. -->
