### PR TITLE
update Java installation to use openjdk-21-jdk

### DIFF
--- a/Ch01/01_02-challenge-deploy-a-jenkins-server/jenkins-server-automated-installation.sh
+++ b/Ch01/01_02-challenge-deploy-a-jenkins-server/jenkins-server-automated-installation.sh
@@ -17,12 +17,12 @@ echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
     /etc/apt/sources.list.d/jenkins.list > /dev/null
 
 # install java, nginx, and jenkins
-echo "# $(date) Install Java 11, NGINX, and Jenkins..."
+echo "# $(date) Install Java 21, NGINX, and Jenkins..."
 apt update
 apt-get -y upgrade
 
 apt-get -y install \
-    openjdk-11-jdk \
+    openjdk-21-jdk \
     nginx \
     ca-certificates \
     curl \

--- a/Ch01/01_03-solution-deploy-a-jenkins-server/jenkins-server-automated-installation.sh
+++ b/Ch01/01_03-solution-deploy-a-jenkins-server/jenkins-server-automated-installation.sh
@@ -17,12 +17,12 @@ echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
     /etc/apt/sources.list.d/jenkins.list > /dev/null
 
 # install java, nginx, and jenkins
-echo "# $(date) Install Java 11, NGINX, and Jenkins..."
+echo "# $(date) Install Java 21, NGINX, and Jenkins..."
 apt update
 apt-get -y upgrade
 
 apt-get -y install \
-    openjdk-11-jdk \
+    openjdk-21-jdk \
     nginx \
     ca-certificates \
     curl \


### PR DESCRIPTION
Updates the following installation scripts to use Java openjdk-21-jdk:

- `./Ch01/01_03-solution-deploy-a-jenkins-server/jenkins-server-automated-installation.sh`
- `./Ch01/01_02-challenge-deploy-a-jenkins-server/jenkins-server-automated-installation.sh`

Closes:
- #11 
- #12 
- #13 

